### PR TITLE
feat: Added getNumberOfCenturiesSinceJ2000() to epoch module in @observerly/astrometry.

### DIFF
--- a/src/epoch.ts
+++ b/src/epoch.ts
@@ -42,3 +42,21 @@ export const getModifiedJulianDate = (datetime: Date): number => {
 }
 
 /*****************************************************************************************************************/
+
+/**
+ *
+ * getNumberOfCenturiesSinceJ2000()
+ *
+ * @param datetime - The date for which to calculate the number of centuries since J2000.0.
+ * @returns number - the number of centuries since J2000.0.
+ *
+ */
+export const getNumberOfCenturiesSinceJ2000 = (datetime: Date): number => {
+  // Get the Julian Date (JD) of the given date normalised to UTC:
+  const JD = getJulianDate(datetime)
+
+  // Calculate the number of centuries since J2000.0:
+  return (JD - 2451545.0) / 36525
+}
+
+/*****************************************************************************************************************/

--- a/tests/epoch.spec.ts
+++ b/tests/epoch.spec.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest'
 
 /*****************************************************************************************************************/
 
-import { getJulianDate, getModifiedJulianDate } from '../src'
+import { getJulianDate, getModifiedJulianDate, getNumberOfCenturiesSinceJ2000 } from '../src'
 
 /*****************************************************************************************************************/
 
@@ -41,6 +41,17 @@ describe('Modified Julian Date', () => {
   it('should return the Modified Julian Date (MJD) of the given date', () => {
     const MJD = getModifiedJulianDate(datetime)
     expect(MJD).toBe(59348)
+  })
+})
+
+describe('getNumberOfCenturiesSinceJ2000', () => {
+  it('should be defined', () => {
+    expect(getNumberOfCenturiesSinceJ2000).toBeDefined()
+  })
+
+  it('should return the number of centuries since J2000.0', () => {
+    const T = getNumberOfCenturiesSinceJ2000(datetime)
+    expect(T).toBe(0.21364818617385353)
   })
 })
 


### PR DESCRIPTION
feat: Added getNumberOfCenturiesSinceJ2000() to epoch module in @observerly/astrometry.

Includes associated test suite and expected API output.