### PR TITLE
feat: Added getGreenwhichSiderealTime() to astrometry module in @observerly/astrometry.

### DIFF
--- a/src/astrometry.ts
+++ b/src/astrometry.ts
@@ -6,6 +6,66 @@
 
 /*****************************************************************************************************************/
 
-export {}
+import { getJulianDate } from './epoch'
+
+import { utc } from './utc'
+
+/*****************************************************************************************************************/
+
+/**
+ *
+ * getGreenwhichSiderealTime()
+ *
+ * The Greenwich Sidereal Time (GST) is the hour angle of the vernal
+ * equinox, the ascending node of the ecliptic on the celestial equator.
+ *
+ * @param date - The date for which to calculate the Greenwich Sidereal Time (GST).
+ * @returns Greenwich Sidereal Time as number - the Greenwich Sidereal Time (GST) of the given date normalised to UTC.
+ *
+ */
+export const getGreenwhichSiderealTime = (datetime: Date): number => {
+  const JD = getJulianDate(datetime)
+
+  const JD_0 = Math.floor(JD - 0.5) + 0.5
+
+  const S = JD_0 - 2451545.0
+
+  const T = S / 36525.0
+
+  let T_0 = (6.697374558 + 2400.051336 * T + 0.000025862 * Math.pow(T, 2)) % 24
+
+  if (T_0 < 0) {
+    T_0 += 24
+  }
+
+  // Ensure that the date is in UTC
+  const d = utc(datetime)
+
+  // Convert the UTC time to a decimal fraction of hours:
+  const UTC =
+    d.getUTCMilliseconds() / 1e-6 +
+    d.getUTCSeconds() / 60 +
+    d.getUTCMinutes() / 60 +
+    d.getUTCHours()
+
+  const A = UTC * 1.002737909
+
+  T_0 += A
+
+  let GST = T_0 + A
+
+  GST = GST % 24
+
+  return GST < 0 ? GST + 24 : GST
+}
+
+/*****************************************************************************************************************/
+
+/**
+ *
+ * @alias getGreenwhichSiderealTime()
+ *
+ */
+export const GST = getGreenwhichSiderealTime
 
 /*****************************************************************************************************************/

--- a/tests/astrometry.spec.ts
+++ b/tests/astrometry.spec.ts
@@ -1,0 +1,34 @@
+/*****************************************************************************************************************/
+
+// @author         Michael Roberts <michael@observerly.com>
+// @package        @observerly/astrometry/epoch
+// @license        Copyright © 2021-2023 observerly
+
+/*****************************************************************************************************************/
+
+import { describe, expect, it } from 'vitest'
+
+/*****************************************************************************************************************/
+
+import { getGreenwhichSiderealTime } from '../src'
+
+/*****************************************************************************************************************/
+
+// For testing we need to specify a date because most calculations are
+// differential w.r.t a time component. We set it to the author's birthday:
+export const datetime = new Date('2021-05-14T00:00:00.000+00:00')
+
+/*****************************************************************************************************************/
+
+describe('getGreenwhichSiderealTime', () => {
+  it('should be defined', () => {
+    expect(getGreenwhichSiderealTime).toBeDefined()
+  })
+
+  it('should return the Julian Date (JD) of the given date', () => {
+    const GST = getGreenwhichSiderealTime(datetime)
+    expect(GST).toBe(15.463990399019053)
+  })
+})
+
+/*****************************************************************************************************************/


### PR DESCRIPTION
feat: Added getGreenwhichSiderealTime() to astrometry module in @observerly/astrometry. 

Includes associated test suite and expected API output.