### PR TITLE
feat: Added getLocalSiderealTime() to astrometry module in @observerly/astrometry.

### DIFF
--- a/src/astrometry.ts
+++ b/src/astrometry.ts
@@ -24,16 +24,22 @@ import { utc } from './utc'
  *
  */
 export const getGreenwhichSiderealTime = (datetime: Date): number => {
+  // Get the Julian Date of the given date:
   const JD = getJulianDate(datetime)
 
+  // Get the Julian Date of the previous midnight:
   const JD_0 = Math.floor(JD - 0.5) + 0.5
 
+  // Get the number of days since the previous midnight:
   const S = JD_0 - 2451545.0
 
+  // Get the number of centuries since J2000.0:
   const T = S / 36525.0
 
+  // Calculate the Greenwich Sidereal Time (GST) at 0h UT:
   let T_0 = (6.697374558 + 2400.051336 * T + 0.000025862 * Math.pow(T, 2)) % 24
 
+  // Ensure that the Greenwich Sidereal Time (GST) is positive:
   if (T_0 < 0) {
     T_0 += 24
   }
@@ -67,5 +73,43 @@ export const getGreenwhichSiderealTime = (datetime: Date): number => {
  *
  */
 export const GST = getGreenwhichSiderealTime
+
+/*****************************************************************************************************************/
+
+/**
+ *
+ * getLocalSiderealTime()
+ *
+ * The Local Sidereal Time (LST) is the hour angle of the vernal
+ * equinox, the ascending node of the ecliptic on the celestial equator.
+ *
+ * @param date - The date for which to calculate the Local Sidereal Time (LST).
+ * @param longitude - The longitude of the observer in degrees.
+ * @returs Local Sidereal Time as number - the Local Sidereal Time (LST) of the given date normalised to UTC.
+ *
+ */
+export const getLocalSiderealTime = (datetime: Date, longitude: number): number => {
+  // Get the Greenwich Sidereal Time (GST) of the given date:
+  const GST = getGreenwhichSiderealTime(datetime)
+
+  let d = (GST + longitude / 15.0) / 24.0
+
+  d = d - Math.floor(d)
+
+  if (d < 0) {
+    d += 1
+  }
+
+  return 24.0 * d
+}
+
+/*****************************************************************************************************************/
+
+/**
+ *
+ * @alias getLocalSiderealTime()
+ *
+ */
+export const LST = getLocalSiderealTime
 
 /*****************************************************************************************************************/

--- a/tests/astrometry.spec.ts
+++ b/tests/astrometry.spec.ts
@@ -10,13 +10,16 @@ import { describe, expect, it } from 'vitest'
 
 /*****************************************************************************************************************/
 
-import { getGreenwhichSiderealTime } from '../src'
+import { getGreenwhichSiderealTime, getLocalSiderealTime } from '../src'
 
 /*****************************************************************************************************************/
 
 // For testing we need to specify a date because most calculations are
 // differential w.r.t a time component. We set it to the author's birthday:
 export const datetime = new Date('2021-05-14T00:00:00.000+00:00')
+
+// For testing we will fix the longitude to be Manua Kea, Hawaii, US:
+export const longitude = -155.468094
 
 /*****************************************************************************************************************/
 
@@ -25,10 +28,27 @@ describe('getGreenwhichSiderealTime', () => {
     expect(getGreenwhichSiderealTime).toBeDefined()
   })
 
-  it('should return the Julian Date (JD) of the given date', () => {
+  it('should return the Greenwhich Sidereal Time (GST) of the given date', () => {
     const GST = getGreenwhichSiderealTime(datetime)
     expect(GST).toBe(15.463990399019053)
   })
 })
 
 /*****************************************************************************************************************/
+
+describe('getLocalSiderealTime', () => {
+  it('should be defined', () => {
+    expect(getLocalSiderealTime).toBeDefined()
+  })
+
+  it('should return the Local Sidereal Time (LST) of the given date at longitude 0 at Greenwhich', () => {
+    const LST = getLocalSiderealTime(datetime, 0)
+    const GST = getGreenwhichSiderealTime(datetime)
+    expect(LST).toBe(GST)
+  })
+
+  it('should return the Local Sidereal Time (LST) of the given date', () => {
+    const LST = getLocalSiderealTime(datetime, longitude)
+    expect(LST).toBe(5.099450799019053)
+  })
+})


### PR DESCRIPTION
feat: Added getLocalSiderealTime() to astrometry module in @observerly/astrometry. 

Includes associated test suite and expected API output.