### PR TITLE
feat: Added getAirmassPickering() to seeing module in @observerly/astrometry.

### DIFF
--- a/src/seeing.ts
+++ b/src/seeing.ts
@@ -6,6 +6,30 @@
 
 /*****************************************************************************************************************/
 
-export {}
+import { type HorizontalCoordinate } from './common'
+
+import { convertDegreesToRadians as radians } from './utilities'
+
+/*****************************************************************************************************************/
+
+/**
+ *
+ * getAirmassPickering()
+ *
+ * Airmass is a measure of the amount of air along the line of sight when observing a star
+ * or other celestial source from below Earth's atmosphere. It is formulated
+ * as the integral of air density along the light ray.
+ *
+ * @see Pickering, K. A. (2002). "The Southern Limits of the Ancient Star Catalog" (PDF). DIO. 12 (1): 20-39.
+ * @param target - The horizontal coordinate of the observed object.
+ * @returns The airmass of the object.
+ *
+ */
+export const getAirmassPickering = (target: HorizontalCoordinate): number => {
+  const { alt } = target
+
+  // Apply Pickering's formula to the altitude of the object:
+  return 1 / Math.sin(radians(alt + 244 / (165 + 47 * Math.pow(alt, 1.1))))
+}
 
 /*****************************************************************************************************************/

--- a/tests/seeing.spec.ts
+++ b/tests/seeing.spec.ts
@@ -1,0 +1,36 @@
+/*****************************************************************************************************************/
+
+// @author         Michael Roberts <michael@observerly.com>
+// @package        @observerly/astrometry/epoch
+// @license        Copyright © 2021-2023 observerly
+
+/*****************************************************************************************************************/
+
+import { describe, expect, it } from 'vitest'
+
+/*****************************************************************************************************************/
+
+import { getAirmassPickering } from '../src'
+
+/*****************************************************************************************************************/
+
+// For testing we need to specify a date because most calculations are
+// differential w.r.t a time component. We set it to the author's birthday:
+export const datetime = new Date('2021-05-14T00:00:00.000+00:00')
+
+/*****************************************************************************************************************/
+
+describe('getAirmassPickering', () => {
+  it('should be defined', () => {
+    expect(getAirmassPickering).toBeDefined()
+  })
+
+  it('should return the correct airmass value for an object both at the horizon and near the zenith', () => {
+    let X = getAirmassPickering({ alt: 0, az: 0 })
+    expect(X).toBeCloseTo(38.75)
+    X = getAirmassPickering({ alt: 72.78539444063767, az: 0 })
+    expect(X).toBe(1.0466433379575284)
+  })
+})
+
+/*****************************************************************************************************************/


### PR DESCRIPTION
feat: Added getAirmassPickering() to seeing module in @observerly/astrometry. 

Includes associated test suite and expected API output.