### PR TITLE
feat: Added getMeanGeometricLongitude() to moon module in @observerly/astrometry.

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -45,3 +45,39 @@ export const getMeanAnomaly = (datetime: Date): number => {
 }
 
 /*****************************************************************************************************************/
+
+/**
+ *
+ * getMeanGeometricLongitude()
+ *
+ * The Moon's mean geometric longitude is the angle between the Moon's current
+ * position and the vernal equinox.
+ *
+ * @param date - The date to calculate the Moon's mean geometric longitude for.
+ * @returns The Moon's mean geometric longitude at the given date.
+ *
+ */
+export const getMeanGeometricLongitude = (datetime: Date): number => {
+  // Get the Julian date:
+  const JD = getJulianDate(datetime)
+
+  // Calculate the number of centuries since J2000.0:
+  const T = (JD - 2451545.0) / 36525
+
+  let l =
+    (218.3164477 +
+      481267.88123421 * T -
+      0.0015786 * Math.pow(T, 2) +
+      Math.pow(T, 3) / 538841 -
+      Math.pow(T, 4) / 65194000) %
+    360
+
+  // Correct for negative angles
+  if (l < 0) {
+    l += 360
+  }
+
+  return l
+}
+
+/*****************************************************************************************************************/

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest'
 
 /*****************************************************************************************************************/
 
-import { getMeanAnomaly } from '../src'
+import { getMeanAnomaly, getMeanGeometricLongitude } from '../src'
 
 /*****************************************************************************************************************/
 
@@ -25,9 +25,22 @@ describe('getMeanAnomaly', () => {
     expect(getMeanAnomaly).toBeDefined()
   })
 
-  it('should return the Julian Date (JD) of the given date', () => {
+  it('should return the correct Lunar mean anomaly for the given date', () => {
     const M = getMeanAnomaly(datetime)
     expect(M).toBe(207.63633585681964)
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getMeanGeometricLongitude', () => {
+  it('should be defined', () => {
+    expect(getMeanGeometricLongitude).toBeDefined()
+  })
+
+  it('should return the correct Lunar mean geometric longitude for the given date', () => {
+    const l = getMeanGeometricLongitude(datetime)
+    expect(l).toBe(80.32626508452813)
   })
 })
 


### PR DESCRIPTION
feat: Added getMeanGeometricLongitude() to moon module in @observerly/astrometry. 

Includes associated test suite and expected API output.