### PR TITLE
feat: Added getMeanEclipticLongitude() to moon module in @observerly/…

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -81,3 +81,34 @@ export const getMeanGeometricLongitude = (datetime: Date): number => {
 }
 
 /*****************************************************************************************************************/
+
+/**
+ *
+ * getMeanEclipticLongitude()
+ *
+ * The mean lunar ecliptic longitude is the ecliptic longitude of the Moon
+ * if the Moon's orbit where free of perturbations
+ *
+ * @param date - The date to calculate the Moon's mean ecliptic longitude for.
+ * @returns The Moon's mean ecliptic longitude at the given date.
+ *
+ */
+export const getMeanEclipticLongitude = (datetime: Date): number => {
+  // Get the Julian date:
+  const JD = getJulianDate(datetime)
+
+  // Get the number of days since the standard epoch J2000:
+  const De = JD - 2451545.0
+
+  // Get the uncorrected mean eclptic longitude:
+  let λ = (13.176339686 * De + 218.31643388) % 360
+
+  // Correct for negative angles
+  if (λ < 0) {
+    λ += 360
+  }
+
+  return λ
+}
+
+/*****************************************************************************************************************/

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest'
 
 /*****************************************************************************************************************/
 
-import { getMeanAnomaly, getMeanGeometricLongitude } from '../src'
+import { getMeanAnomaly, getMeanGeometricLongitude, getMeanEclipticLongitude } from '../src'
 
 /*****************************************************************************************************************/
 
@@ -41,6 +41,19 @@ describe('getMeanGeometricLongitude', () => {
   it('should return the correct Lunar mean geometric longitude for the given date', () => {
     const l = getMeanGeometricLongitude(datetime)
     expect(l).toBe(80.32626508452813)
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getMeanEclipticLongitude', () => {
+  it('should be defined', () => {
+    expect(getMeanEclipticLongitude).toBeDefined()
+  })
+
+  it('should return the correct Lunar mean ecliptic longitude for the given date', () => {
+    const λ = getMeanEclipticLongitude(datetime)
+    expect(λ).toBe(79.88317358099448)
   })
 })
 


### PR DESCRIPTION
feat: Added getMeanEclipticLongitude() to moon module in @observerly/astrometry. 

Includes associated test suite and expected API output.