### PR TITLE
feat: Added getBodyNextRise() to transit module in @observerly/astrometry.

### DIFF
--- a/src/transit.ts
+++ b/src/transit.ts
@@ -13,7 +13,13 @@ import {
   isEquatorialCoordinate,
   isHorizontalCoordinate
 } from './common'
+
 import { convertEquatorialToHorizontal } from './coordinates'
+
+import {
+  convertLocalSiderealTimeToGreenwhichSiderealTime,
+  convertGreenwhichSiderealTimeToUniversalTime
+} from './temporal'
 
 import {
   getNormalizedInclinationDegree,
@@ -306,6 +312,74 @@ export const getBodyTransit = (
     LSTs,
     R,
     S
+  }
+}
+
+/*****************************************************************************************************************/
+
+/**
+ *
+ * getBodyNextRise()
+ *
+ * Determines the next rise time for an object, if at all.
+ *
+ * @param date - The date to start searching for the next rise.
+ * @param observer - The geographic coordinate of the observer.
+ * @param target - The equatorial coordinate of the observed object.
+ * @param horizon - The observer's horizon (in degrees).
+ * @returns The next rise time or False if the object never rises, or True if the object is always above the horizon (circumpolar) for the observer.
+ */
+export const getBodyNextRise = (
+  datetime: Date,
+  observer: GeographicCoordinate,
+  target: EquatorialCoordinate,
+  horizon: number = 0
+): TransitInstance | boolean => {
+  const tomorrow = new Date(
+    datetime.getFullYear(),
+    datetime.getMonth(),
+    datetime.getDate() + 1,
+    0,
+    0,
+    0,
+    0
+  )
+
+  // If the object is circumpolar, it never rises:
+  if (isBodyCircumpolar(observer, target, horizon)) {
+    return true
+  }
+
+  // If the object is never visible, it never rises:
+  if (!isBodyVisible(observer, target, horizon)) {
+    return false
+  }
+
+  const transit = getBodyTransit(observer, target)
+
+  if (!transit) {
+    // Get the next rise time for the next day:
+    return getBodyNextRise(tomorrow, observer, target, horizon)
+  }
+
+  const LSTr = transit.LSTr
+
+  // Convert the local sidereal time of rise to Greenwhich sidereal time:
+  const GSTr = convertLocalSiderealTimeToGreenwhichSiderealTime(LSTr, observer)
+
+  // Convert the Greenwhich sidereal time to universal coordinate time for the date specified:
+  const rise = convertGreenwhichSiderealTimeToUniversalTime(GSTr, datetime)
+
+  // If the rise is before the current time, then we know the next rise is tomorrow:
+  if (rise < datetime) {
+    return getBodyNextRise(tomorrow, observer, target, horizon)
+  }
+
+  return {
+    datetime: rise,
+    LST: transit.LSTr,
+    GST: GSTr,
+    az: transit.R
   }
 }
 

--- a/tests/transit.spec.ts
+++ b/tests/transit.spec.ts
@@ -16,7 +16,8 @@ import {
   isBodyVisible,
   isBodyAboveHorizon,
   doesBodyRiseOrSet,
-  getBodyTransit
+  getBodyTransit,
+  getBodyNextRise
 } from '../src'
 
 /*****************************************************************************************************************/
@@ -305,6 +306,38 @@ describe('getBodyTransit', () => {
     expect(LSTs).toBe(12.098575460027751)
     expect(R).toBeCloseTo(82.12362992591511)
     expect(S).toBeCloseTo(277.8763700740849)
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getBodyNextRise', () => {
+  it('should be defined', () => {
+    expect(getBodyNextRise).toBeDefined()
+  })
+
+  it('should return transit parameters for a northerm hemisphere object for a postive latitude', () => {
+    const rise = getBodyNextRise(
+      new Date('2021-05-14T21:00:00.000+00:00'),
+      {
+        latitude,
+        longitude
+      },
+      betelgeuse
+    )
+
+    expect(rise).toBeDefined()
+    expect(rise).not.toBeFalsy()
+    expect(rise).not.toBe(true)
+
+    if (typeof rise === 'boolean') return
+
+    const { GST, LST, az, datetime: d } = rise
+
+    expect(GST).toBe(10.105025246638917)
+    expect(LST).toBe(23.740485646638913)
+    expect(az).toBeCloseTo(82.12362992591511)
+    expect(d).toStrictEqual(new Date('2021-05-15T18:31:28.713Z'))
   })
 })
 


### PR DESCRIPTION
feat: Added getBodyNextRise() to transit module in @observerly/astrometry. 

Includes associated test suite and expected API output.