### PR TITLE
feat: Added getLunarTrueAnomaly() to moon module in @observerly/astrometry.

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -199,3 +199,30 @@ export const getLunarMeanAnomalyCorrection = (datetime: Date) => {
 }
 
 /*****************************************************************************************************************/
+
+/**
+ *
+ * getLunarTrueAnomaly()
+ *
+ * The true anomaly of the Moon is the angle between the perihelion and the
+ * current position of the Moon, as seen from the Earth.
+ *
+ * @param date - The date to calculate the Moon's true anomaly for.
+ * @returns The Moon's true anomaly in degrees.
+ */
+export const getLunarTrueAnomaly = (datetime: Date): number => {
+  // Get the mean anomaly correction:
+  const Ca = getLunarMeanAnomalyCorrection(datetime)
+
+  // Get the true anomaly:
+  let ν = 6.2886 * Math.sin(radians(Ca)) + ((0.214 * Math.sin(radians(2 * Ca))) % 360)
+
+  // Correct for negative angles
+  if (ν < 0) {
+    ν += 360
+  }
+
+  return ν
+}
+
+/*****************************************************************************************************************/

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -17,7 +17,8 @@ import {
   getLunarMeanEclipticLongitude,
   getLunarEvectionCorrection,
   getLunarMeanEclipticLongitudeOfTheAscendingNode,
-  getLunarMeanAnomalyCorrection
+  getLunarMeanAnomalyCorrection,
+  getLunarTrueAnomaly
 } from '../src'
 
 /*****************************************************************************************************************/
@@ -114,6 +115,19 @@ describe('getLunarMeanAnomalyCorrection', () => {
   it('should return the correct Lunar mean anomaly correction for the given date', () => {
     const Ac = getLunarMeanAnomalyCorrection(datetime)
     expect(Ac).toBe(206.64428333417192)
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getLunarTrueAnomaly', () => {
+  it('should be defined', () => {
+    expect(getLunarTrueAnomaly).toBeDefined()
+  })
+
+  it('should return the correct Lunar true anomaly for the given date', () => {
+    const ν = getLunarTrueAnomaly(datetime)
+    expect(ν).toBe(357.3514315617634)
   })
 })
 


### PR DESCRIPTION
feat: Added getLunarTrueAnomaly() to moon module in @observerly/astrometry. 

Includes associated test suite and expected API output.