### PR TITLE
feat: Added getLunarCorrectedEclipticLongitudeOfTheAscendingNode() to moon module in @observerly/astrometry.

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -276,3 +276,27 @@ export const getLunarTrueEclipticLongitude = (datetime: Date): number => {
 }
 
 /*****************************************************************************************************************/
+
+/**
+ *
+ * getLunarCorrectedEclipticLongitudeOfTheAscendingNode()
+ *
+ * The corrected lunar ecliptic longitude of the ascending node is the angle where
+ * the Moon's orbit crosses the ecliptic corrected for perturbations in the
+ * Moon's orbit due to the Sun.
+ *
+ * @param date - The date to calculate the Moon's corrected ecliptic latitude for.
+ * @returns The Moon's corrected ecliptic latitude in degrees.
+ *
+ */
+export const getLunarCorrectedEclipticLongitudeOfTheAscendingNode = (datetime: Date): number => {
+  // Get the ecliptic longitude of the ascending node:
+  const Ω = getLunarMeanEclipticLongitudeOfTheAscendingNode(datetime)
+
+  // Get the solar mean anomaly:
+  const M = getSolarMeanAnomaly(datetime)
+
+  return Ω - 0.16 * Math.sin(radians(M))
+}
+
+/*****************************************************************************************************************/

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -19,7 +19,8 @@ import {
   getLunarMeanEclipticLongitudeOfTheAscendingNode,
   getLunarMeanAnomalyCorrection,
   getLunarTrueAnomaly,
-  getLunarTrueEclipticLongitude
+  getLunarTrueEclipticLongitude,
+  getLunarCorrectedEclipticLongitudeOfTheAscendingNode
 } from '../src'
 
 /*****************************************************************************************************************/
@@ -142,6 +143,19 @@ describe('getLunarTrueEclipticLongitude', () => {
   it('should return the correct Lunar true ecliptic longitude for the given date', () => {
     const λ = getLunarTrueEclipticLongitude(datetime)
     expect(λ).toBe(77.01224128076132)
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getLunarCorrectedEclipticLongitudeOfTheAscendingNode', () => {
+  it('should be defined', () => {
+    expect(getLunarCorrectedEclipticLongitudeOfTheAscendingNode).toBeDefined()
+  })
+
+  it('should return the correct Lunar corrected ecliptic longitude of the ascending node for the given date', () => {
+    const Ω = getLunarCorrectedEclipticLongitudeOfTheAscendingNode(datetime)
+    expect(Ω).toBe(71.56888914504515)
   })
 })
 


### PR DESCRIPTION
feat: Added getLunarCorrectedEclipticLongitudeOfTheAscendingNode() to moon module in @observerly/astrometry.

Includes associated test suite and expected API output.