### PR TITLE
feat: Added getLunarEclipticLongitude() to moon module in @observerly/astrometry.

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -10,7 +10,7 @@ import { getJulianDate } from './epoch'
 
 import { getSolarMeanAnomaly, getSolarEclipticLongitude } from './sun'
 
-import { convertDegreesToRadians as radians } from './utilities'
+import { convertDegreesToRadians as radians, convertRadiansToDegrees as degrees } from './utilities'
 
 /*****************************************************************************************************************/
 
@@ -297,6 +297,47 @@ export const getLunarCorrectedEclipticLongitudeOfTheAscendingNode = (datetime: D
   const M = getSolarMeanAnomaly(datetime)
 
   return Ω - 0.16 * Math.sin(radians(M))
+}
+
+/*****************************************************************************************************************/
+
+/**
+ *
+ * getLunarEclipticLongitude()
+ *
+ * The ecliptic longitude for the Moon is the angle between the perihelion and
+ * the current position of the Moon, as seen from the centre of the Earth,
+ * corrected for the equation of center and the Moon's ecliptic longitude at
+ * perigee at the epoch.
+ *
+ * @param date - The date to calculate the Moon's ecliptic longitude for.
+ * @returns The Moon's ecliptic longitude in degrees.
+ *
+ */
+export const getLunarEclipticLongitude = (datetime: Date): number => {
+  // Get the true ecliptic longitude:
+  const λt = getLunarTrueEclipticLongitude(datetime)
+
+  // Get the corrected ecliptic longitude of the ascending node:
+  const Ωcorr = getLunarCorrectedEclipticLongitudeOfTheAscendingNode(datetime)
+
+  // Get the Moon's orbital inclination:
+  const ι = radians(5.1453964)
+
+  // Calculate the ecliptic longitude of the Moon (in degrees):
+  let λ =
+    (Ωcorr +
+      degrees(
+        Math.atan2(Math.sin(radians(λt - Ωcorr)) * Math.cos(ι), Math.cos(radians(λt - Ωcorr)))
+      )) %
+    360
+
+  // Correct for negative angles
+  if (λ < 0) {
+    λ += 360
+  }
+
+  return λ
 }
 
 /*****************************************************************************************************************/

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -20,7 +20,8 @@ import {
   getLunarMeanAnomalyCorrection,
   getLunarTrueAnomaly,
   getLunarTrueEclipticLongitude,
-  getLunarCorrectedEclipticLongitudeOfTheAscendingNode
+  getLunarCorrectedEclipticLongitudeOfTheAscendingNode,
+  getLunarEclipticLongitude
 } from '../src'
 
 /*****************************************************************************************************************/
@@ -156,6 +157,19 @@ describe('getLunarCorrectedEclipticLongitudeOfTheAscendingNode', () => {
   it('should return the correct Lunar corrected ecliptic longitude of the ascending node for the given date', () => {
     const Ω = getLunarCorrectedEclipticLongitudeOfTheAscendingNode(datetime)
     expect(Ω).toBe(71.56888914504515)
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getLunarEclipticLongitude', () => {
+  it('should be defined', () => {
+    expect(getLunarEclipticLongitude).toBeDefined()
+  })
+
+  it('should return the correct Lunar ecliptic longitude for the given date', () => {
+    const λ = getLunarEclipticLongitude(datetime)
+    expect(λ).toBe(76.99043727540315)
   })
 })
 


### PR DESCRIPTION
feat: Added getLunarEclipticLongitude() to moon module in @observerly/astrometry. 

Includes associated test suite and expected API output.