### PR TITLE
feat: Added getLunarAge() to moon module in @observerly/astrometry.

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -545,3 +545,43 @@ export const getLunarDistance = (datetime: Date): number => {
 }
 
 /*****************************************************************************************************************/
+
+/**
+ *
+ * getLunarAge()
+ *
+ * The age of the Moon is calculated by ascertaining the number of degrees
+ * the Moon has traversed in it's orbit, given that it takes the Moon
+ * 29.5306 days to traverse a full 360° in one orbit cycle.
+ *
+ * @param date - The date to calculate the Moon's age for.
+ * @returns The Moon's age in both degrees and days.
+ *
+ */
+export const getLunarAge = (date: Date): { A: number; age: number } => {
+  // Get the true ecliptic longitude:
+  const λt = getLunarTrueEclipticLongitude(date)
+
+  // Get the solar ecliptic longitude:
+  const λ = getSolarEclipticLongitude(date)
+
+  // Get the Moon's age in degrees:
+  let A = (λt - λ) % 360
+
+  // Correct for negative angles:
+  if (A < 0) {
+    A += 360
+  }
+
+  // Get the Moon's age in days by multiplying the age, A,
+  // by the number of degrees traversed per day given that
+  // the Moon orbits the Earth every 29.5306 days:
+  const age = A * (29.5306 / 360)
+
+  return {
+    A,
+    age
+  }
+}
+
+/*****************************************************************************************************************/

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -27,7 +27,8 @@ import {
   getLunarEquatorialCoordinate,
   getLunarElongation,
   getLunarAngularDiameter,
-  getLunarDistance
+  getLunarDistance,
+  getLunarAge
 } from '../src'
 
 /*****************************************************************************************************************/
@@ -260,6 +261,21 @@ describe('getLunarDistance', () => {
     const datetime = new Date('2015-01-02T03:00:00.000+00:00')
     const Δ = getLunarDistance(datetime)
     expect(Δ).toBe(363410767.06392413)
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getLunarAge', () => {
+  it('should be defined', () => {
+    expect(getLunarAge).toBeDefined()
+  })
+
+  it('should return the correct Lunar age for the given date', () => {
+    const datetime = new Date('2015-01-01T00:00:00.000+00:00')
+    const { A, age } = getLunarAge(datetime)
+    expect(A).toBe(130.40251122256336)
+    expect(age).toBe(10.696845549747305)
   })
 })
 


### PR DESCRIPTION
feat: Added getLunarAge() to moon module in @observerly/astrometry. 

Includes associated test suite and expected API output.