### PR TITLE
feat: Added getLunarIllumination() to moon module in @observerly/astr…

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -614,3 +614,25 @@ export const getLunarPhaseAngle = (datetime: Date): number => {
 }
 
 /*****************************************************************************************************************/
+
+/**
+ *
+ * getLunarIllimination()
+ *
+ * The total percentage illumination of the Moon as seen from Earth
+ * (i.e., the visible portion of the Moon), not to be confused with
+ * the total illumination of the Moon by the Sun which is always 50%.
+ *
+ * @param date - The date to calculate the Moon's phase angle for.
+ * @returns The Moon's illumination as a percentage of the visible portion of the Moon as seen from Earth.
+ *
+ */
+export const getLunarIllumination = (datetime: Date): number => {
+  // Get the phase angle:
+  const PA = getLunarPhaseAngle(datetime)
+
+  // Get the total illuminated % fraction:
+  return 50 * (1 + Math.cos(radians(PA)))
+}
+
+/*****************************************************************************************************************/

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -29,7 +29,8 @@ import {
   getLunarAngularDiameter,
   getLunarDistance,
   getLunarAge,
-  getLunarPhaseAngle
+  getLunarPhaseAngle,
+  getLunarIllumination
 } from '../src'
 
 /*****************************************************************************************************************/
@@ -291,6 +292,20 @@ describe('getLunarPhaseAngle', () => {
     const datetime = new Date('2015-01-01T00:00:00.000+00:00')
     const PA = getLunarPhaseAngle(datetime)
     expect(PA).toBe(49.66441438659977)
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getLunarIllumination', () => {
+  it('should be defined', () => {
+    expect(getLunarIllumination).toBeDefined()
+  })
+
+  it('should return the correct Lunar illumination for the given date', () => {
+    const datetime = new Date('2015-01-01T00:00:00.000+00:00')
+    const K = getLunarIllumination(datetime)
+    expect(K).toBe(82.36316687224799)
   })
 })
 


### PR DESCRIPTION
feat: Added getLunarIllumination() to moon module in @observerly/astrometry. 

Includes associated test suite and expected API output.