### PR TITLE
ci: Amend @observerly/astrometry for public publishing.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     env:
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_OBSERVERLY_PUBLIC_TOKEN }}
 
     steps:
       - name: Checkout 🛎
@@ -50,11 +50,11 @@ jobs:
       - name: Build the package ready for publishing
         run: pnpm run build
 
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@v3
         with:
-          registry: 'https://npm.pkg.github.com'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          check-version: true
+          registry: 'https://registry.npmjs.org/'
+          access: 'public'
+          token: ${{ secrets.NPM_OBSERVERLY_PUBLIC_TOKEN }}
 
       - if: steps.publish.outputs.type != 'none'
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -7,7 +7,7 @@
 #/*****************************************************************************************************************/
 
 registry=https://registry.npmjs.org/
-@observerly:registry=https://npm.pkg.github.com
+@observerly:registry=https://registry.npmjs.org/
 //npm.pkg.github.com/:_authToken=${NPM_TOKEN}
 
 #/*****************************************************************************************************************/

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@observerly/astrometry",
   "version": "0.22.0",
   "description": "observerly's lightweight, zero-dependency, type safe astrometry library written in Typescript.",
+  "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/observerly/astrometry.git"


### PR DESCRIPTION
ci: Amend @observerly/astrometry for public publishing. 

includes updated .npmrc file with scoped npm @observerly:registry. 

Includes updated { private } in package.json to false.

Includes updating JS-DevTools/npm-publish action to version 3.0.0.