### PR TITLE
feat: amend getGreenwhichSiderealTime() utility to be accurate up to ms in @observerly/astrometry.

### DIFF
--- a/src/astrometry.ts
+++ b/src/astrometry.ts
@@ -85,9 +85,7 @@ export const getGreenwhichSiderealTime = (datetime: Date): number => {
   const d = utc(datetime)
 
   // Convert the UTC time to a decimal fraction of hours:
-  const UTC =
-    ((d.getUTCMilliseconds() / 1000 + d.getUTCSeconds()) / 60 + d.getUTCMinutes()) / 60 +
-    d.getUTCHours()
+  const UTC = d.getUTCHours() + d.getUTCMinutes() / 60 + d.getUTCSeconds() / 3600 + d.getUTCMilliseconds() / 3600000
 
   const A = UTC * 1.002737909
 

--- a/tests/astrometry.spec.ts
+++ b/tests/astrometry.spec.ts
@@ -78,6 +78,13 @@ describe('getLocalSiderealTime', () => {
     expect(LST).toBe(GST)
   })
 
+  it('should return the Local Sidereal Time (LST) of the given date at longitude 0 at Greenwhich', () => {
+    const datetime = new Date('2021-05-14T01:06:33.99870+00:00')
+    const LST = getLocalSiderealTime(datetime, 0)
+    const GST = getGreenwhichSiderealTime(datetime)
+    expect(LST).toBe(GST)
+  })
+
   it('should return the Local Sidereal Time (LST) of the given date', () => {
     const LST = getLocalSiderealTime(datetime, longitude)
     expect(LST).toBe(5.099450799019053)


### PR DESCRIPTION
feat: amend getGreenwhichSiderealTime() utility to be accurate up to ms in @observerly/astrometry.