### PR TITLE
feat: add Datetime.getHeliocentricJulianDate() class method to time module in @observerly/astrometry.

### DIFF
--- a/src/time.ts
+++ b/src/time.ts
@@ -10,6 +10,8 @@ import { getJulianDate, getModifiedJulianDate } from './epoch'
 
 import { LEAP_SECONDS } from './iers'
 
+import { getHeliocentricJulianDate } from './sun'
+
 /*****************************************************************************************************************/
 
 // This is the number of milliseconds to correct for a given zeroth date according to the IERS table.
@@ -160,6 +162,26 @@ export class DateTime extends Date {
    */
   getMJD(): number {
     return this.getModifiedJulianDate()
+  }
+
+  /**
+   *
+   *
+   * @returns Heliocentric Julian Date as number - the Heliocentric Julian Date (HJD) of the given date.
+   *
+   */
+  getHeliocentricJulianDate(): number {
+    return getHeliocentricJulianDate(this)
+  }
+
+  /**
+   *
+   *
+   * @returns Heliocentric Julian Date as number - the Heliocentric Julian Date (HJD) of the given date.
+   *
+   */
+  getHJD(): number {
+    return this.getHeliocentricJulianDate()
   }
 }
 

--- a/tests/time.spec.ts
+++ b/tests/time.spec.ts
@@ -71,6 +71,25 @@ describe('DateTime Modified Julian Dates', () => {
 
 /*****************************************************************************************************************/
 
+describe('DateTime Heliocentric Julian Dates', () => {
+  it('should have a getHeliocentricJulianDate method', () => {
+    expect(new DateTime().getHeliocentricJulianDate).toBeDefined()
+    expect(new DateTime().getHeliocentricJulianDate).toBeInstanceOf(Function)
+  })
+
+  it('should have a getHJD method', () => {
+    expect(new DateTime().getHJD).toBeDefined()
+    expect(new DateTime().getHJD).toBeInstanceOf(Function)
+  })
+
+  it('should return the Heliocentric Julian Date (HJD) of the given date', () => {
+    const HJD = new DateTime(datetime).getHeliocentricJulianDate()
+    expect(HJD).toBeCloseTo(2459348.49416325)
+  })
+})
+
+/*****************************************************************************************************************/
+
 describe('DateTime International Atomic Time', () => {
   it('should have a getInternationalAtomicTime method', () => {
     expect(new DateTime().getInternationalAtomicTime).toBeDefined()


### PR DESCRIPTION
feat: add Datetime.getHeliocentricJulianDate() class method to time module in @observerly/astrometry.