### PR TITLE
fix: improve getLunarPhase() precision around Full Moon & New Moon in @observerly/astrometry

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -52,7 +52,8 @@ export const Phases = {
   Full: 'Full',
   WaningGibbous: 'Waning Gibbous',
   LastQuarter: 'Last Quarter',
-  WaningCrescent: 'Waning Crescent'
+  WaningCrescent: 'Waning Crescent',
+  Invalid: 'Invalid'
 } as const
 
 export type Phase = (typeof Phases)[keyof typeof Phases]
@@ -729,11 +730,10 @@ export const getLunarPhase = (datetime: Date): Phase => {
   // Get the age of the Moon:
   const { age } = getLunarAge(datetime)
 
-  // Determine the phase of the Moon:
-  if (age < 1.84566) {
-    return Phases.New
-  }
+  // Get the illuniated fraction of the Moon (as a percentage):
+  const illumination = getLunarIllumination(datetime)
 
+  // Determine the phase of the Moon based off of the age and the illumination:
   if (age < 5.53699) {
     return Phases.WaxingCrescent
   }
@@ -742,11 +742,12 @@ export const getLunarPhase = (datetime: Date): Phase => {
     return Phases.FirstQuarter
   }
 
-  if (age < 12.91963) {
+  if (age < 14.71963) {
     return Phases.WaxingGibbous
   }
 
-  if (age < 16.61096) {
+  // If the illumination is +/- 1% of 100% illumination then the Moon is full:
+  if (age < 15.02096 && Math.abs(illumination - 100) < 1) {
     return Phases.Full
   }
 

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -388,13 +388,15 @@ describe.each([
   }))
 ])('isNewMoon', ({ date }) => {
   it('should return only when the Moon is a New Moon', () => {
-    const d = new Date(date.getTime() - date.getTimezoneOffset() * 60000)
-
-    if ([12, 13, 14].includes(d.getDate()) && d.getMonth() === 0 && d.getFullYear() === 2021) {
-      expect(isNewMoon(d)).toBe(true)
+    if ([12, 13].includes(date.getDate()) && date.getMonth() === 0 && date.getFullYear() === 2021) {
+      expect(isNewMoon(date)).toBe(true)
     } else {
-      expect(isNewMoon(d)).toBe(false)
+      expect(isNewMoon(date)).toBe(false)
     }
+  })
+
+  it('should never return an invalid phase', () => {
+    expect(getLunarPhase(date) === 'Invalid').toBe(false)
   })
 })
 
@@ -406,15 +408,19 @@ describe.each([
   }))
 ])('isFullMoon', ({ date }) => {
   it('should return only when the Moon is a Full Moon', () => {
-    if (
-      [1, 27, 28, 29, 30].includes(date.getDate()) &&
-      date.getMonth() === 0 &&
-      date.getFullYear() === 2021
-    ) {
+    if ([29].includes(date.getDate()) && date.getMonth() === 0 && date.getFullYear() === 2021) {
       expect(isFullMoon(date)).toBe(true)
     } else {
       expect(isFullMoon(date)).toBe(false)
     }
+  })
+
+  it('should never return an invalid phase', () => {
+    if (getLunarPhase(date) === 'Invalid') {
+      console.log(date)
+    }
+
+    expect(getLunarPhase(date) === 'Invalid').toBe(false)
   })
 })
 


### PR DESCRIPTION
fix: improve getLunarPhase() precision around Full Moon & New Moon in @observerly/astrometry