### PR TITLE
style: remove console.logs in test suits across workspace in @observerly/astrometry

### DIFF
--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -418,10 +418,6 @@ describe.each([
   })
 
   it('should never return an invalid phase', () => {
-    if (getLunarPhase(date) === 'Invalid') {
-      console.log(date)
-    }
-
     expect(getLunarPhase(date) === 'Invalid').toBe(false)
   })
 })

--- a/tests/transit.spec.ts
+++ b/tests/transit.spec.ts
@@ -503,15 +503,9 @@ describe('getBodyNextRise and getBodyNextSet maximum call stack size error', () 
     }
 
     const set = getBodyNextSet(datetime, observer, target, 0.8190762287002356)
-
-    console.log(set)
-
     expect(set).toBeDefined()
 
     const rise = getBodyNextRise(datetime, observer, target, 0.8190762287002356)
-
-    console.log(rise)
-
     expect(rise).toBeDefined()
   })
 
@@ -533,15 +527,9 @@ describe('getBodyNextRise and getBodyNextSet maximum call stack size error', () 
     }
 
     const set = getBodyNextSet(datetime, observer, target, 0.8190762287002356)
-
-    console.log(set)
-
     expect(set).toBeDefined()
 
     const rise = getBodyNextRise(datetime, observer, target, 0.8190762287002356)
-
-    console.log(rise)
-
     expect(rise).toBeDefined()
   })
 
@@ -563,15 +551,9 @@ describe('getBodyNextRise and getBodyNextSet maximum call stack size error', () 
     }
 
     const set = getBodyNextSet(datetime, observer, target, 0.8190762287002356)
-
-    console.log(set)
-
     expect(set).toBeDefined()
 
     const rise = getBodyNextRise(datetime, observer, target, 0.8190762287002356)
-
-    console.log(rise)
-
     expect(rise).toBeDefined()
   })
 })


### PR DESCRIPTION
style: remove console.logs in test suits across workspace in @observerly/astrometry