### PR TITLE
fix: account for arcsine trigonometric boundaries for convertEquator by ialToHorizontal in @observerly/astrometry

### DIFF
--- a/src/coordinates.ts
+++ b/src/coordinates.ts
@@ -142,14 +142,29 @@ export const convertEquatorialToHorizontal = (
   // Get the hour angle for the target:
   const ha = radians(getHourAngle(datetime, longitude, target.ra))
 
+  // Calculate the altitude of the target, ensuring it is within the range -π/2 to π/2 for arcsin,
+  // i.e., between [-1, 1]. This accounts for the observer's target being directly overhead, e.g., at the zenith,
+  // or directly below the observer, e.g., at the nadir.
   const altitude = Math.asin(
-    Math.sin(declination) * Math.sin(radians(latitude)) +
-      Math.cos(declination) * Math.cos(radians(latitude)) * Math.cos(ha)
+    Math.max(
+      -1,
+      Math.min(
+        1,
+        Math.sin(declination) * Math.sin(radians(latitude)) +
+          Math.cos(declination) * Math.cos(radians(latitude)) * Math.cos(ha)
+      )
+    )
   )
 
   const azimuth = Math.acos(
-    (Math.sin(declination) - Math.sin(altitude) * Math.sin(radians(latitude))) /
-      (Math.cos(altitude) * Math.cos(radians(latitude)))
+    Math.max(
+      -1,
+      Math.min(
+        1,
+        (Math.sin(declination) - Math.sin(radians(latitude)) * Math.sin(altitude)) /
+          (Math.cos(radians(latitude)) * Math.cos(altitude))
+      )
+    )
   )
 
   return {

--- a/tests/astrometry.spec.ts
+++ b/tests/astrometry.spec.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest'
 /*****************************************************************************************************************/
 
 import {
+  convertEquatorialToHorizontal,
   type EquatorialCoordinate,
   getAngularSeparation,
   getAntipodeCoordinate,
@@ -128,6 +129,20 @@ describe('getGreenwhichSiderealTime', () => {
   it('should return the Greenwhich Sidereal Time (GST) of the given date', () => {
     const GST = getGreenwhichSiderealTime(datetime)
     expect(GST).toBe(15.463990399019053)
+  })
+
+  it('should return a target that is directly overhead at for ', () => {
+    const GST = getGreenwhichSiderealTime(datetime)
+
+    // The observer is at the same latitude as Betelgeuse's declination, and the same longitude as as
+    // Betelgeuse's right ascension minus the GST times 15 degrees per hour:
+    // This simulates a target directly overhead for the "observer":
+    const observer = { latitude: betelgeuse.dec, longitude: betelgeuse.ra - GST * 15 }
+
+    // Convert the target to horizontal coordinates:
+    const target = convertEquatorialToHorizontal(datetime, observer, betelgeuse)
+    // The target should be directly overhead:
+    expect(target.alt).toBe(90)
   })
 })
 

--- a/tests/coordinates.spec.ts
+++ b/tests/coordinates.spec.ts
@@ -15,7 +15,8 @@ import {
   convertEclipticToEquatorial,
   convertEquatorialToHorizontal,
   convertGalacticToEquatorial,
-  convertHorizontalToEquatorial
+  convertHorizontalToEquatorial,
+  getGreenwhichSiderealTime
 } from '../src'
 
 /*****************************************************************************************************************/
@@ -63,6 +64,22 @@ describe('convertEquatorialToHorizontal', () => {
     const { alt, az } = convertEquatorialToHorizontal(datetime, { latitude, longitude }, betelgeuse)
     expect(alt).toBe(72.78539444063765)
     expect(az).toBe(134.44877920325155)
+  })
+
+  it('should return the correct horizontal coodinate for a target directly overhead for the datetime provided', () => {
+    const GST = getGreenwhichSiderealTime(datetime)
+
+    // The observer is at the same latitude as Betelgeuse's declination, and the same longitude as as
+    // Betelgeuse's right ascension minus the GST times 15 degrees per hour:
+    // This simulates a target directly overhead for the "observer":
+    const observer = { latitude: betelgeuse.dec, longitude: betelgeuse.ra - GST * 15 }
+
+    // Convert the target to horizontal coordinates:
+    const target = convertEquatorialToHorizontal(datetime, observer, betelgeuse)
+    // The target should be directly overhead:
+    expect(target.alt).toBe(90)
+    // The target should be at the observer's meridian:
+    expect(target.az).toBe(270)
   })
 })
 


### PR DESCRIPTION
fix: ensure we account for arc trigonometric boundaries for convertEquatorialToHorizontal in @observerly/astrometry

---

Calculates the altitude of the target, ensuring it is within the range -π/2 to π/2 for arcsin, i.e., between [-1, 1]. This accounts for the observer's target being directly overhead, e.g., at the zenith, or directly below the observer, e.g., at the nadir.