### PR TITLE
fix: amend Antila typo in constellations module in @observerly/astrometry

### DIFF
--- a/src/constellations.ts
+++ b/src/constellations.ts
@@ -107,7 +107,7 @@ export { vulpecula } from './constellations/vulpecula'
 
 export type ConstellationName =
   | 'Andromeda'
-  | 'Antlia'
+  | 'Antila'
   | 'Apus'
   | 'Aquarius'
   | 'Aquila'
@@ -246,9 +246,9 @@ export const constellations: Map<ConstellationName, Constellation> = new Map<
     }
   ],
   [
-    'Antlia',
+    'Antila',
     {
-      name: 'Antlia',
+      name: 'Antila',
       meaning: 'The Air Pump',
       abbreviation: 'Ant'
     }


### PR DESCRIPTION
fix: amend Antila typo in constellations module in @observerly/astrometry