### PR TITLE
refactor: amend getSolarEquatorialCoordinate() to use accurate ecliptic coordinate lookup in sun module in @observerly/astrometry

### DIFF
--- a/src/sun.ts
+++ b/src/sun.ts
@@ -6,11 +6,11 @@
 
 /*****************************************************************************************************************/
 
-import { getObliquityOfTheEcliptic } from './astrometry'
-
 import { type EclipticCoordinate, type EquatorialCoordinate } from './common'
 
 import { AU_IN_METERS, c } from './constants'
+
+import { convertEclipticToEquatorial } from './coordinates'
 
 import { B, getEccentricityOfOrbit, L, R } from './earth'
 
@@ -18,7 +18,7 @@ import { getJulianDate } from './epoch'
 
 import { getFOrbitalParameter } from './orbit'
 
-import { convertRadiansToDegrees as degrees, convertDegreesToRadians as radians } from './utilities'
+import { convertDegreesToRadians as radians } from './utilities'
 
 import { calculateB, calculateL, calculateR } from './vsop87'
 
@@ -202,7 +202,7 @@ export const getSolarEclipticLongitude = (datetime: Date): number => {
 
 /**
  *
- * getSolarEclipticCoordinates()
+ * getSolarEclipticCoordinate()
  *
  * The ecliptic coordinates of the Sun are the Sun's position in the sky as seen
  * from the centre of the Earth, corrected for the equation of center and the Sun's
@@ -211,7 +211,7 @@ export const getSolarEclipticLongitude = (datetime: Date): number => {
  * @param datetime - The date to calculate the Sun's ecliptic coordinates for.
  * @returns The Sun's ecliptic coordinates at the given date.
  */
-export function getSolarEclipticCoordinates(datetime: Date): EclipticCoordinate & {
+export function getSolarEclipticCoordinate(datetime: Date): EclipticCoordinate & {
   R: number
 } {
   // Get the Julian date:
@@ -306,29 +306,11 @@ export function getSolarEclipticCoordinates(datetime: Date): EclipticCoordinate 
  *
  */
 export const getSolarEquatorialCoordinate = (datetime: Date): EquatorialCoordinate => {
-  // Get the ecliptic longitude:
-  const λ = radians(getSolarEclipticLongitude(datetime))
-
-  // Get the ecliptic latitude:
-  // This term is zero for the Sun, so we can largely ignore it by refactoring
+  // Get the ecliptic coordinates of the Sun:
+  // The latitude, β, term is close to zero for the Sun, so we can largely ignore it by refactoring
   // the standard equations for the conversion between ecliptic and equatorial
   // coordinates.
-  // const β = 0
-
-  // Get the obliquity of the ecliptic:
-  const ε = radians(getObliquityOfTheEcliptic(datetime))
-
-  // Get the corresponding Right Ascension, α:
-  let ra = degrees(Math.atan2(Math.sin(λ) * Math.cos(ε), Math.cos(λ))) % 360
-
-  // Correct ra for negative angles
-  if (ra < 0) {
-    ra += 360
-  }
-
-  const dec = degrees(Math.asin(Math.sin(ε) * Math.sin(λ)))
-
-  return { ra, dec }
+  return convertEclipticToEquatorial(datetime, getSolarEclipticCoordinate(datetime))
 }
 
 /*****************************************************************************************************************/

--- a/tests/night.spec.ts
+++ b/tests/night.spec.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest'
 
 /*****************************************************************************************************************/
 
-import { getSolarTransit, getNight, isNight } from '../src'
+import { getNight, getSolarTransit, isNight } from '../src'
 
 /*****************************************************************************************************************/
 
@@ -45,9 +45,9 @@ describe('getSolarTransit', () => {
     expect(noon).toBeInstanceOf(Date)
     expect(sunset).toBeInstanceOf(Date)
 
-    expect(sunrise?.toISOString()).toBe('2021-05-14T04:45:57.636Z')
+    expect(sunrise?.toISOString()).toBe('2021-05-14T04:46:57.636Z')
     expect(noon?.toISOString()).toBe('2021-05-14T12:21:40.985Z')
-    expect(sunset?.toISOString()).toBe('2021-05-14T19:55:24.334Z')
+    expect(sunset?.toISOString()).toBe('2021-05-14T19:57:24.334Z')
   })
 
   it('should return the correct solar transit for the observer at a horizon of -6 degrees', () => {
@@ -64,9 +64,9 @@ describe('getSolarTransit', () => {
     expect(noon).toBeInstanceOf(Date)
     expect(sunset).toBeInstanceOf(Date)
 
-    expect(sunrise?.toISOString()).toBe('2021-05-14T04:00:57.636Z')
+    expect(sunrise?.toISOString()).toBe('2021-05-14T04:01:57.636Z')
     expect(noon?.toISOString()).toBe('2021-05-14T12:21:40.985Z')
-    expect(sunset?.toISOString()).toBe('2021-05-14T20:41:24.334Z')
+    expect(sunset?.toISOString()).toBe('2021-05-14T20:43:24.334Z')
   })
 })
 
@@ -90,8 +90,8 @@ describe('getNight', () => {
     expect(start).toBeInstanceOf(Date)
     expect(end).toBeInstanceOf(Date)
 
-    expect(start?.toISOString()).toBe('2021-05-14T19:55:24.334Z')
-    expect(end?.toISOString()).toBe('2021-05-15T04:45:03.311Z')
+    expect(start?.toISOString()).toBe('2021-05-14T19:57:24.334Z')
+    expect(end?.toISOString()).toBe('2021-05-15T04:46:03.311Z')
   })
 
   it('should return the correct night for the observer at a horizon of -18 degrees', () => {
@@ -107,8 +107,8 @@ describe('getNight', () => {
     expect(start).toBeInstanceOf(Date)
     expect(end).toBeInstanceOf(Date)
 
-    expect(start?.toISOString()).toBe('2021-05-14T22:47:46.972Z')
-    expect(end?.toISOString()).toBe('2021-05-15T10:32:31.677Z')
+    expect(start?.toISOString()).toBe('2021-05-14T22:49:46.972Z')
+    expect(end?.toISOString()).toBe('2021-05-15T10:34:31.677Z')
   })
 })
 

--- a/tests/sun.spec.ts
+++ b/tests/sun.spec.ts
@@ -17,7 +17,7 @@ import {
   getJulianDate,
   getSolarAngularDiameter,
   getSolarDistance,
-  getSolarEclipticCoordinates,
+  getSolarEclipticCoordinate,
   getSolarEclipticLongitude,
   getSolarEquationOfCenter,
   getSolarEquatorialCoordinate,
@@ -114,14 +114,14 @@ describe('getSolarEclipticLongitude', () => {
 
 /*****************************************************************************************************************/
 
-describe('getSolarEclipticCoordinates', () => {
+describe('getSolarEclipticCoordinate', () => {
   it('should be defined', () => {
-    expect(getSolarEclipticCoordinates).toBeDefined()
+    expect(getSolarEclipticCoordinate).toBeDefined()
   })
 
   it('should return the correct Solar ecliptic longitude for the given date', () => {
     const datetime = new Date('2015-02-05T12:00:00.000+00:00')
-    const { λ, β } = getSolarEclipticCoordinates(datetime)
+    const { λ, β } = getSolarEclipticCoordinate(datetime)
     expect(λ).toBeCloseTo(316.35605539442895)
     expect(β).toBeCloseTo(0)
 
@@ -146,8 +146,8 @@ describe('getSolarEquatorialCoordinate', () => {
   it('should return the correct Solar equatorial coordinate for the given date', () => {
     const datetime = new Date('2015-02-05T12:00:00.000+00:00')
     const { ra: α, dec: δ } = getSolarEquatorialCoordinate(datetime)
-    expect(α).toBe(318.5617376411268)
-    expect(δ).toBe(-16.008394691469505)
+    expect(α).toBe(318.8121016210669)
+    expect(δ).toBe(-15.933194068491067)
   })
 })
 


### PR DESCRIPTION
refactor: amend getSolarEquatorialCoordinate() to use accurate ecliptic coordinate lookup in sun module in @observerly/astrometry