### PR TITLE
0.61.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@observerly/astrometry",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "exports": "./src/index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observerly/astrometry",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "observerly's lightweight, zero-dependency, type safe astrometry library written in Typescript for calculating the position of celestial objects in the sky.",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## 0.61.0

Bumps the package version `0.60.0` → `0.61.0` in preparation for release.

### Included since `0.60.0`
- `feat`: add `convertHorizontalToPolar` to the projection module — a zenith-centered azimuthal equidistant ("polar") projection of horizontal coordinates for mapping the night sky.
- `feat`: add `convertPolarToHorizontal` to the projection module — the inverse of the polar projection.

This is a minor version bump (new, backwards-compatible features).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1AcSBgAZmaggnixamJWzS)_