### PR TITLE
fix: amend getLunarMeanEclipticLongitudeOfTheAscendingNode in moon module in @observerly/astrometry

### DIFF
--- a/src/moon.ts
+++ b/src/moon.ts
@@ -326,10 +326,7 @@ export const getLunarMeanEclipticLongitudeOfTheAscendingNode = (datetime: Date):
     Ω += 360
   }
 
-  // Correct for the Sun's mean anomaly:
-  const M = radians(getSolarMeanAnomaly(datetime))
-
-  return Ω - 0.16 * Math.sin(M)
+  return Ω
 }
 
 /*****************************************************************************************************************/

--- a/tests/aberration.spec.ts
+++ b/tests/aberration.spec.ts
@@ -44,14 +44,14 @@ describe('getCorrectionToEquatorialForAnnualAberration', () => {
       new Date('2000-01-01T00:00:00+00:00'),
       betelgeuse
     )
-    expect(ra + betelgeuse.ra).toBe(88.79868732900589)
-    expect(dec + betelgeuse.dec).toBe(7.4068039145745)
+    expect(ra + betelgeuse.ra).toBe(88.79868732900594)
+    expect(dec + betelgeuse.dec).toBe(7.406803914569333)
   })
 
   it('should return the correct aberration correction for the designated epoch', () => {
     const { ra, dec } = getCorrectionToEquatorialForAnnualAberration(datetime, betelgeuse)
-    expect(ra + betelgeuse.ra).toBe(88.78837512114575)
-    expect(dec + betelgeuse.dec).toBe(7.406109156062398)
+    expect(ra + betelgeuse.ra).toBe(88.78837512114313)
+    expect(dec + betelgeuse.dec).toBe(7.406109156361687)
   })
 })
 
@@ -101,8 +101,8 @@ describe('getCorrectionToEquatorialForAberration', () => {
       },
       betelgeuse
     )
-    expect(ra + betelgeuse.ra).toBe(88.79875665605677)
-    expect(dec + betelgeuse.dec).toBe(7.406836962857944)
+    expect(ra + betelgeuse.ra).toBe(88.79875665605681)
+    expect(dec + betelgeuse.dec).toBe(7.406836962852777)
   })
 
   it('should return the correct aberration correction for the designated epoch', () => {
@@ -110,8 +110,8 @@ describe('getCorrectionToEquatorialForAberration', () => {
       latitude,
       longitude
     }, betelgeuse)
-    expect(ra + betelgeuse.ra).toBe(88.78844263611573)
-    expect(dec + betelgeuse.dec).toBe(7.4061425995174766)
+    expect(ra + betelgeuse.ra).toBe(88.78844263611312)
+    expect(dec + betelgeuse.dec).toBe(7.406142599816765)
   })
 })
 

--- a/tests/moon.spec.ts
+++ b/tests/moon.spec.ts
@@ -146,7 +146,15 @@ describe('getLunarMeanEclipticLongitudeOfTheAscendingNode', () => {
 
   it('should return the correct Lunar mean ecliptic longitude of the ascending node for the given date', () => {
     const Ω = getLunarMeanEclipticLongitudeOfTheAscendingNode(datetime)
-    expect(Ω).toBe(71.6938262475226)
+    expect(Ω).toBe(71.81876335000004)
+  })
+
+  it('should return the mean (uncorrected) ascending node for the Meeus example epoch', () => {
+    // Meeus, Astronomical Algorithms, Example 22.a (1987 April 10.0 TD), Ω = 11.2531 degrees:
+    const Ω = getLunarMeanEclipticLongitudeOfTheAscendingNode(
+      new Date('1987-04-10T00:00:00.000+00:00')
+    )
+    expect(Ω).toBeCloseTo(11.2531, 1)
   })
 })
 
@@ -198,7 +206,7 @@ describe('getLunarCorrectedEclipticLongitudeOfTheAscendingNode', () => {
 
   it('should return the correct Lunar corrected ecliptic longitude of the ascending node for the given date', () => {
     const Ω = getLunarCorrectedEclipticLongitudeOfTheAscendingNode(datetime)
-    expect(Ω).toBe(71.56888914504515)
+    expect(Ω).toBe(71.6938262475226)
   })
 })
 
@@ -211,7 +219,7 @@ describe('getLunarEclipticLongitude', () => {
 
   it('should return the correct Lunar ecliptic longitude for the given date', () => {
     const λ = getLunarEclipticLongitude(datetime)
-    expect(λ).toBe(76.99043727540315)
+    expect(λ).toBe(76.99093192958355)
   })
 })
 
@@ -224,7 +232,7 @@ describe('getLunarEclipticLatitude', () => {
 
   it('should return the correct Lunar ecliptic latitude for the given date', () => {
     const β = getLunarEclipticLatitude(datetime)
-    expect(β).toBe(0.48745043387361126)
+    expect(β).toBe(0.4762946273566161)
   })
 })
 
@@ -237,8 +245,8 @@ describe('getLunarEclipticCoordinate', () => {
 
   it('should return the correct Lunar ecliptic coordinate for the given date', () => {
     const { λ, β } = getLunarEclipticCoordinate(datetime)
-    expect(λ).toBe(76.99043727540315)
-    expect(β).toBe(0.48745043387361126)
+    expect(λ).toBe(76.99093192958355)
+    expect(β).toBe(0.4762946273566161)
   })
 })
 
@@ -252,8 +260,8 @@ describe('getLunarEquatorialCoordinate', () => {
   it('should return the correct Lunar equatorial coordinate for the given date', () => {
     const datetime = new Date('2015-01-02T03:00:00.000+00:00')
     const { ra, dec } = getLunarEquatorialCoordinate(datetime)
-    expect(ra).toBe(63.85408978307256)
-    expect(dec).toBe(17.246094608898055)
+    expect(ra).toBe(63.854145131019)
+    expect(dec).toBe(17.245818740686968)
   })
 })
 
@@ -267,7 +275,7 @@ describe('getLunarElongation', () => {
   it('should return the correct Lunar elongation for the given date', () => {
     const datetime = new Date('2015-01-02T03:00:00.000+00:00')
     const E = getLunarElongation(datetime)
-    expect(E).toBe(143.73394864456367)
+    expect(E).toBe(143.73392572872314)
   })
 })
 
@@ -336,7 +344,7 @@ describe('getLunarPhaseAngle', () => {
   it('should return the correct Lunar phase angle for the given date', () => {
     const datetime = new Date('2015-01-01T00:00:00.000+00:00')
     const PA = getLunarPhaseAngle(datetime)
-    expect(PA).toBe(49.66441438659977)
+    expect(PA).toBe(49.66445064326936)
   })
 })
 
@@ -350,7 +358,7 @@ describe('getLunarIllumination', () => {
   it('should return the correct Lunar illumination for the given date', () => {
     const datetime = new Date('2015-01-01T00:00:00.000+00:00')
     const K = getLunarIllumination(datetime)
-    expect(K).toBe(82.36316687224799)
+    expect(K).toBe(82.3631427541967)
   })
 })
 
@@ -478,7 +486,7 @@ describe('getNextFullMoon', () => {
 
   it('should return the correct date of the next Full Moon', () => {
     const nextFullMoon = getNextFullMoon(datetime)
-    expect(nextFullMoon.toISOString()).toBe('2021-05-26T11:31:20.000Z')
+    expect(nextFullMoon.toISOString()).toBe('2021-05-26T11:31:30.000Z')
   })
 })
 

--- a/tests/nutation.spec.ts
+++ b/tests/nutation.spec.ts
@@ -39,14 +39,14 @@ describe('getCorrectionToEquatorialForNutation', () => {
       new Date('2000-01-01T00:00:00+00:00'),
       betelgeuse
     )
-    expect(ra + betelgeuse.ra).toBe(88.78918586713395)
-    expect(dec + betelgeuse.dec).toBe(7.4054349663419785)
+    expect(ra + betelgeuse.ra).toBe(88.78918548764206)
+    expect(dec + betelgeuse.dec).toBe(7.405435271760147)
   })
 
   it('should return the correct nutation correction for the designated epoch', () => {
     const { ra, dec } = getCorrectionToEquatorialForNutation(datetime, betelgeuse)
-    expect(ra + betelgeuse.ra).toBe(88.78822826957918)
-    expect(dec + betelgeuse.dec).toBe(7.407781283524082)
+    expect(ra + betelgeuse.ra).toBe(88.78822492448745)
+    expect(dec + betelgeuse.dec).toBe(7.407776028046682)
   })
 })
 

--- a/tests/observation.spec.ts
+++ b/tests/observation.spec.ts
@@ -46,8 +46,8 @@ describe('Observation', () => {
       datetime: new Date('2000-01-01T00:00:00.000+00:00')
     })
 
-    expect(Polaris.ra).toBe(38.246703757962564)
-    expect(Polaris.dec).toBe(89.26695677270877)
+    expect(Polaris.ra).toBe(38.24667700313655)
+    expect(Polaris.dec).toBe(89.26695684006057)
   })
 
   it('should be a reactive observable when the datetime changes', () => {
@@ -62,8 +62,8 @@ describe('Observation', () => {
     })
 
     expect(Polaris.datetime.getTime()).toEqual(datetime.getTime())
-    expect(Polaris.ra).toBe(44.38466115151809)
-    expect(Polaris.dec).toBe(89.350860331493)
+    expect(Polaris.ra).toBe(44.384912894110755)
+    expect(Polaris.dec).toBe(89.35085602969696)
     expect(Polaris.ha).toBe(getHourAngle(datetime, longitude, Polaris.ra))
   })
 


### PR DESCRIPTION
fix: amend getLunarMeanEclipticLongitudeOfTheAscendingNode in moon module in @observerly/astrometry