### PR TITLE
feat: add getGeocentricRotationalVelocity to observer module in @observerly/astrometry

### DIFF
--- a/src/aberration.ts
+++ b/src/aberration.ts
@@ -10,7 +10,7 @@ import { getHourAngle } from './astrometry'
 
 import type { CartesianCoordinate, EquatorialCoordinate, GeographicCoordinate } from './common'
 
-import { EARTH_RADIUS, c } from './constants'
+import { EARTH_ANGULAR_VELOCITY, EARTH_RADIUS, c } from './constants'
 
 import { getEccentricityOfOrbit } from './earth'
 
@@ -139,11 +139,8 @@ export const getCorrectionToEquatorialForDiurnalAberration = (
   // Get the hour angle for the target (in radians):
   const ha = radians(getHourAngle(datetime, observer.longitude, target.ra))
 
-  // Earth's angular velocity (in rad/s):
-  const Ω = 7.292115e-5
-
   // Calculate the observer's tangential velocity at the equator due to Earth's rotation (in m/s):
-  const v = Ω * EARTH_RADIUS
+  const v = radians(EARTH_ANGULAR_VELOCITY) * EARTH_RADIUS
 
   // The constant of diurnal aberration, e.g., the ratio of the observer's velocity to the speed of
   // light, which is ~0.32 arcseconds for an observer at the equator (in radians):

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,19 @@ export const EARTH_RADIUS = 6.3781378e6 as const
 
 /**
  *
+ * The angular velocity of the sidereal rotation of the Earth (in degrees per second), e.g., the
+ * rate at which it turns about its axis against the stars: one whole turn of 360° per sidereal
+ * day of ~86,164.0905 seconds, which is the ~360.9856° it turns through per mean solar day of
+ * 86,400 seconds, as the Earth must turn a little beyond a whole turn for the Sun to return to
+ * the meridian. Equivalent to the 7.292115e-5 radians per second of the IERS.
+ *
+ */
+export const EARTH_ANGULAR_VELOCITY = 0.004178074132240403 as const
+
+/*****************************************************************************************************************/
+
+/**
+ *
  * The Astronomical Unit (AU) is a unit of length defined as the average distance
  * between the Earth and the Sun.
  *

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -6,11 +6,13 @@
 
 /*****************************************************************************************************************/
 
-import { EARTH_RADIUS } from './constants'
+import { getLocalSiderealTime } from './astrometry'
 
-import type { Observer } from './common'
+import { EARTH_ANGULAR_VELOCITY, EARTH_RADIUS } from './constants'
 
-import { convertRadiansToDegrees } from './utilities'
+import type { CartesianCoordinate, GeographicCoordinate, Observer } from './common'
+
+import { convertRadiansToDegrees, convertDegreesToRadians as radians } from './utilities'
 
 /*****************************************************************************************************************/
 
@@ -47,6 +49,52 @@ export const getLocalHorizon = (h: number | Observer, k = 0.167): number => {
   // N.B. The depression is the exact angle subtended, and not its small angle approximation,
   // which diverges for elevations that are an appreciable fraction of the radius of the Earth:
   return convertRadiansToDegrees(Math.acos(EARTH_RADIUS / (EARTH_RADIUS + (1 - k) * elevation)))
+}
+
+/*****************************************************************************************************************/
+
+/**
+ *
+ * getGeocentricRotationalVelocity()
+ *
+ * Calculates the geocentric equatorial velocity of an observer carried by the rotation of the
+ * Earth, e.g., the velocity of an observer at rest at the surface, which carries them towards the
+ * east at up to ~465 metres per second at the equator, and which vanishes at the poles.
+ *
+ * The velocity is resolved in the geocentric equatorial frame, e.g., the frame the velocity of a
+ * spacecraft is resolved in, and so it is the velocity an observer at the surface gives to the
+ * corrections that take one, e.g., the diurnal aberration is the aberration of this velocity.
+ *
+ * @param datetime - The date and time of the observation, which orients the observer about the axis of rotation.
+ * @param observer - The geographic coordinate of the observer.
+ * @returns The geocentric equatorial velocity of the observer (in SI metres per second).
+ *
+ */
+export const getGeocentricRotationalVelocity = (
+  datetime: Date,
+  observer: GeographicCoordinate
+): Required<CartesianCoordinate> => {
+  const { latitude, longitude, elevation = 0 } = observer
+
+  // The distance of the observer from the axis of rotation, e.g., the radius of the parallel the
+  // rotation carries them about (in SI metres):
+  const axial = (EARTH_RADIUS + elevation) * Math.cos(radians(latitude))
+
+  // The speed of the observer along that parallel (in SI metres per second):
+  const speed = radians(EARTH_ANGULAR_VELOCITY) * axial
+
+  // The right ascension of the meridian of the observer, e.g., the Local Sidereal Time of the
+  // observer (in hours, of 15 degrees each):
+  const α = radians(getLocalSiderealTime(datetime, longitude) * 15)
+
+  // The observer is carried towards the east, e.g., along the direction of increasing right
+  // ascension at their meridian, which is perpendicular to both the axis of rotation and the
+  // direction to the observer:
+  return {
+    x: -speed * Math.sin(α),
+    y: speed * Math.cos(α),
+    z: 0
+  }
 }
 
 /*****************************************************************************************************************/

--- a/tests/aberration.spec.ts
+++ b/tests/aberration.spec.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   type CartesianCoordinate,
+  EARTH_ANGULAR_VELOCITY,
   EARTH_RADIUS,
   type EquatorialCoordinate,
   SPEED_OF_LIGHT,
@@ -95,7 +96,7 @@ describe('getCorrectionToEquatorialForDiurnalAberration', () => {
     // The constant of diurnal aberration is ~0.32 arcseconds at the equator, and it is scaled by
     // the cosine of the observer's latitude, and, in right ascension, by the secant of the
     // declination of the target:
-    const k = ((7.292115e-5 * EARTH_RADIUS) / SPEED_OF_LIGHT) * (180 / Math.PI) * 3600
+    const k = ((radians(EARTH_ANGULAR_VELOCITY) * EARTH_RADIUS) / SPEED_OF_LIGHT) * (180 / Math.PI) * 3600
 
     const bound =
       (k * Math.cos(radians(latitude))) / Math.cos(radians(betelgeuse.dec))
@@ -145,7 +146,7 @@ describe('getCorrectionToEquatorialForDiurnalAberration', () => {
       betelgeuse
     )
 
-    const k = ((7.292115e-5 * EARTH_RADIUS) / SPEED_OF_LIGHT) * (180 / Math.PI) * 3600
+    const k = ((radians(EARTH_ANGULAR_VELOCITY) * EARTH_RADIUS) / SPEED_OF_LIGHT) * (180 / Math.PI) * 3600
 
     // The correction in right ascension is at its bound, and the correction in declination, which
     // scales with the sine of the hour angle, vanishes:

--- a/tests/observer.spec.ts
+++ b/tests/observer.spec.ts
@@ -8,7 +8,16 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { getLocalHorizon, type Observer } from '../src'
+import {
+  getCorrectionToEquatorialForDiurnalAberration,
+  getCorrectionToEquatorialForVelocityAberration,
+  getGeocentricRotationalVelocity,
+  getLocalHorizon,
+  getLocalSiderealTime,
+  type Observer
+} from '../src'
+
+import { convertDegreesToRadians as radians } from '../src/utilities'
 
 /*****************************************************************************************************************/
 
@@ -90,6 +99,85 @@ describe('getLocalHorizon edge cases', () => {
 
       previous = depression
     }
+  })
+})
+
+/*****************************************************************************************************************/
+
+describe('getGeocentricRotationalVelocity', () => {
+  const datetime = new Date('2021-05-14T00:00:00.000+00:00')
+
+  it('should be defined', () => {
+    expect(getGeocentricRotationalVelocity).toBeDefined()
+  })
+
+  it('should carry an observer at the equator at ~465 metres per second', () => {
+    const velocity = getGeocentricRotationalVelocity(datetime, { latitude: 0, longitude: 0 })
+
+    expect(Math.hypot(velocity.x, velocity.y, velocity.z)).toBeCloseTo(465.1, 1)
+
+    // The rotation carries the observer about the axis, and not along it:
+    expect(velocity.z).toBe(0)
+  })
+
+  it('should vanish for an observer at the poles', () => {
+    for (const latitude of [90, -90]) {
+      const velocity = getGeocentricRotationalVelocity(datetime, { latitude, longitude: 0 })
+
+      expect(Math.hypot(velocity.x, velocity.y, velocity.z)).toBeCloseTo(0, 9)
+    }
+  })
+
+  it('should scale with the distance of the observer from the axis of rotation', () => {
+    const surface = getGeocentricRotationalVelocity(datetime, { latitude, longitude })
+
+    const elevated = getGeocentricRotationalVelocity(datetime, { latitude, longitude, elevation: 400000 })
+
+    const ratio = Math.hypot(elevated.x, elevated.y) / Math.hypot(surface.x, surface.y)
+
+    expect(ratio).toBeCloseTo((6.3781378e6 + 400000) / 6.3781378e6, 9)
+  })
+
+  it('should carry the observer towards the east of their meridian', () => {
+    // The velocity is perpendicular to the direction to the observer, along the direction of
+    // increasing right ascension at their meridian:
+    const velocity = getGeocentricRotationalVelocity(datetime, { latitude, longitude })
+
+    const α = radians(getLocalSiderealTime(datetime, longitude) * 15)
+
+    const φ = radians(latitude)
+
+    // The unit vector of the direction to the observer, in the geocentric equatorial frame:
+    const direction = [Math.cos(φ) * Math.cos(α), Math.cos(φ) * Math.sin(α), Math.sin(φ)]
+
+    const dot = velocity.x * direction[0] + velocity.y * direction[1] + velocity.z * direction[2]
+
+    expect(dot).toBeCloseTo(0, 6)
+
+    // The east at the meridian is the direction of increasing right ascension:
+    const east = [-Math.sin(α), Math.cos(α), 0]
+
+    const along = velocity.x * east[0] + velocity.y * east[1] + velocity.z * east[2]
+
+    expect(along).toBeCloseTo(Math.hypot(velocity.x, velocity.y, velocity.z), 6)
+  })
+
+  it('should resolve the diurnal aberration as the aberration of the velocity', () => {
+    // The diurnal aberration is the aberration of the velocity of the rotation of the Earth
+    // carrying the observer, and so the velocity aberration of this velocity agrees with the
+    // diurnal correction, to within the second order of the two formulations:
+    const observer = { latitude, longitude }
+
+    const betelgeuse = { ra: 88.7929583, dec: 7.4070639 }
+
+    const velocity = getGeocentricRotationalVelocity(datetime, observer)
+
+    const resolved = getCorrectionToEquatorialForVelocityAberration(betelgeuse, velocity)
+
+    const diurnal = getCorrectionToEquatorialForDiurnalAberration(datetime, observer, betelgeuse)
+
+    expect(resolved.ra).toBeCloseTo(diurnal.ra, 8)
+    expect(resolved.dec).toBeCloseTo(diurnal.dec, 8)
   })
 })
 


### PR DESCRIPTION
Adds `getGeocentricRotationalVelocity()` to the observer module: the geocentric equatorial velocity of an observer carried by the rotation of the Earth, e.g., ~465 metres per second towards the east at the equator, shortening with the cosine of the latitude and vanishing at the poles.

The velocity is resolved in the same frame as the velocity of a spacecraft, and so it is the velocity an observer at the surface gives to the corrections that take one, e.g., `getApparentEquatorialCoordinate()` — the diurnal aberration is the aberration of this velocity, and the tests pin that closure: the velocity aberration of it agrees with `getCorrectionToEquatorialForDiurnalAberration()` to within the second order of the two formulations.