### PR TITLE
fix: declare the package free of side effects in @observerly/astrometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "type": "module",
+  "sideEffects": false,
   "files": ["dist"],
   "keywords": [
     "astronomy",


### PR DESCRIPTION
Declares the package free of side effects, e.g., `"sideEffects": false`, which is the one bit a bundler needs to tree-shake the barrel: every module of the library is pure computation and constant data, and so a module no import reaches may be dropped in its entirety.

Measured against the packed tarball with esbuild, importing a single converter from the barrel:

| Import | Before | After |
|---|---|---|
| `convertDegreesToRadians` from the barrel | 83,394 bytes | 181 bytes |
| `getSolarEquatorialCoordinate` from the barrel | 90,215 bytes | 7,338 bytes |

The barrel import now bundles identically to the `/utilities` subpath import, and the shaken bundles run correctly. No source, build, or dist changes — the flag alone.