### PR TITLE
fix(constellations)!: correct misspelled Antlia and Triangulum Australe in @observerly/astrometry

### DIFF
--- a/src/constellations.ts
+++ b/src/constellations.ts
@@ -17,7 +17,7 @@ import { getCorrectionToEquatorialForPrecessionOfEquinoxes } from './precession'
 /*****************************************************************************************************************/
 
 import { andromeda } from './constellations/andromeda'
-import { antila } from './constellations/antila'
+import { antlia } from './constellations/antlia'
 import { apus } from './constellations/apus'
 import { aquarius } from './constellations/aquarius'
 import { aquila } from './constellations/aquila'
@@ -96,7 +96,7 @@ import { sextans } from './constellations/sextans'
 import { taurus } from './constellations/taurus'
 import { telescopium } from './constellations/telescopium'
 import { triangulum } from './constellations/triangulum'
-import { triangulumAustralae } from './constellations/triangulumAustralae'
+import { triangulumAustrale } from './constellations/triangulumAustrale'
 import { tucana } from './constellations/tucana'
 import { ursaMajor } from './constellations/ursaMajor'
 import { ursaMinor } from './constellations/ursaMinor'
@@ -109,7 +109,7 @@ import { vulpecula } from './constellations/vulpecula'
 
 export type ConstellationName =
   | 'Andromeda'
-  | 'Antila'
+  | 'Antlia'
   | 'Apus'
   | 'Aquarius'
   | 'Aquila'
@@ -256,12 +256,12 @@ export const constellations: Map<ConstellationName, Constellation> = new Map<
     }
   ],
   [
-    'Antila',
+    'Antlia',
     {
-      name: 'Antila',
+      name: 'Antlia',
       meaning: 'The Air Pump',
       abbreviation: 'Ant',
-      feature: antila
+      feature: antlia
     }
   ],
   [
@@ -981,7 +981,7 @@ export const constellations: Map<ConstellationName, Constellation> = new Map<
       name: 'Triangulum Australe',
       meaning: 'The Southern Triangle',
       abbreviation: 'TrA',
-      feature: triangulumAustralae
+      feature: triangulumAustrale
     }
   ],
   [

--- a/src/constellations/antlia.ts
+++ b/src/constellations/antlia.ts
@@ -1,7 +1,7 @@
 /*****************************************************************************************************************/
 
 // @author         Michael Roberts <michael@observerly.com>
-// @package        @observerly/astrometry/antila
+// @package        @observerly/astrometry/antlia
 // @license        Copyright © 2021-2026 observerly
 
 /*****************************************************************************************************************/
@@ -21,12 +21,12 @@ const centrum: EquatorialCoordinate = {
 
 // prettier-ignore
 const aster: number[][][] = [
-  // ι Antilae to α Antilae:
+  // ι Antliae to α Antliae:
   [
     [164.179167, -37.137472],
     [156.788167, -31.067806]
   ],
-  // α Antilae to ε Antilae:
+  // α Antliae to ε Antliae:
   [
     [156.788167, -31.067806],
     [142.311417, -35.951361]
@@ -58,6 +58,6 @@ const boundary: number[][][] = [
 /*****************************************************************************************************************/
 
 // https://www.iau.org/public/themes/constellations/#ant
-export const antila = createConstellationAsGeoJSON('Antila', 'the pump', centrum, aster, boundary)
+export const antlia = createConstellationAsGeoJSON('Antlia', 'the pump', centrum, aster, boundary)
 
 /*****************************************************************************************************************/

--- a/src/constellations/index.ts
+++ b/src/constellations/index.ts
@@ -7,7 +7,7 @@
 /*****************************************************************************************************************/
 
 export { andromeda } from './andromeda'
-export { antila } from './antila'
+export { antlia } from './antlia'
 export { apus } from './apus'
 export { aquarius } from './aquarius'
 export { aquila } from './aquila'
@@ -86,7 +86,7 @@ export { sextans } from './sextans'
 export { taurus } from './taurus'
 export { telescopium } from './telescopium'
 export { triangulum } from './triangulum'
-export { triangulumAustralae } from './triangulumAustralae'
+export { triangulumAustrale } from './triangulumAustrale'
 export { tucana } from './tucana'
 export { ursaMajor } from './ursaMajor'
 export { ursaMinor } from './ursaMinor'

--- a/src/constellations/triangulumAustrale.ts
+++ b/src/constellations/triangulumAustrale.ts
@@ -1,7 +1,7 @@
 /*****************************************************************************************************************/
 
 // @author         Michael Roberts <michael@observerly.com>
-// @package        @observerly/astrometry/triangulumAustralae
+// @package        @observerly/astrometry/triangulumAustrale
 // @license        Copyright © 2021-2026 observerly
 
 /*****************************************************************************************************************/
@@ -68,7 +68,7 @@ const boundaries: number[][][] = [
 /*****************************************************************************************************************/
 
 // https://www.iau.org/public/themes/constellations/#tra
-export const triangulumAustralae = createConstellationAsGeoJSON(
+export const triangulumAustrale = createConstellationAsGeoJSON(
   'Triangulum Australe',
   'the southern triangle',
   centrum,


### PR DESCRIPTION
fix(constellations)!: correct misspelled Antlia and Triangulum Australe in @observerly/astrometry